### PR TITLE
fix(fakenitro): check if links > 0

### DIFF
--- a/commands/fakenitro.js
+++ b/commands/fakenitro.js
@@ -7,7 +7,8 @@ module.exports = {
     category: 'fun',
     execute: async (client, config, Discord, target, utils, message, args) => {
         const links = parseInt(args[0]) || 1;
-        if (links > 5) links = 5;
+        if (links < 1) links = 1;
+        else if (links > 5) links = 5;
         
         message.channel.send(new Array(links).fill(null).map(() => formatLink()).join(" "));
     },

--- a/commands/fakenitro.js
+++ b/commands/fakenitro.js
@@ -6,7 +6,7 @@ module.exports = {
     description: 'Generates a fake nitro gift link',
     category: 'fun',
     execute: async (client, config, Discord, target, utils, message, args) => {
-        const links = parseInt(args[0]) || 1;
+        let links = parseInt(args[0]) || 1;
         if (links < 1) links = 1;
         else if (links > 5) links = 5;
         


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/30553356/60399763-fbce8d80-9b69-11e9-9bc6-16683f24fe98.png)
When using a negative number as command argument, it will error. This pull request fixes it by using `1` if `links < 0`